### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,8 +18,12 @@ env:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
   build:
+    permissions:
+      contents: read
     needs: test
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/piotr-ku/directadmin-exporter/security/code-scanning/4](https://github.com/piotr-ku/directadmin-exporter/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `build` and `test` jobs. These jobs only require read access to the repository contents, so we will set `contents: read` as the minimal permission. This change ensures that the `GITHUB_TOKEN` used in these jobs has the least privilege necessary to complete the tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
