### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
   coverage:
     if: contains(github.ref, 'main')


### PR DESCRIPTION
Potential fix for [https://github.com/piotr-ku/directadmin-exporter/security/code-scanning/1](https://github.com/piotr-ku/directadmin-exporter/security/code-scanning/1)

To fix the issue, we need to explicitly define the `permissions` block for the `test` job in the parent workflow file. Based on the principle of least privilege, we will start with minimal permissions (`contents: read`) unless the `test` job requires additional permissions. This ensures that the `GITHUB_TOKEN` used by the `test` job has only the necessary access.

The changes will be made in the `.github/workflows/integration.yml` file by adding a `permissions` block under the `test` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
